### PR TITLE
chore: add ownership data to the provisioner CRD

### DIFF
--- a/pkg/apis/crds/karpenter.sh_provisioners.yaml
+++ b/pkg/apis/crds/karpenter.sh_provisioners.yaml
@@ -6,6 +6,10 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: provisioners.karpenter.sh
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "karpenter"
+    meta.helm.sh/release-namespace: "karpenter"
 spec:
   group: karpenter.sh
   names:


### PR DESCRIPTION


<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

* add ownership data, exists and cannot be imported into the current release: invalid ownership metadata
* To avoid:
```
CustomResourceDefinition "provisioners.karpenter.sh" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm
```


**How was this change tested?**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
